### PR TITLE
Create a document via post

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ app.del('/:db/:id/:attachment', function (req, res, next) {
 
 });
 
-// Create a document
+// Create or update document that has an ID
 app.put('/:db/:id(*)', function (req, res, next) {
   req.body._id = req.body._id || req.query.id;
   if (!req.body._id) {
@@ -307,6 +307,14 @@ app.put('/:db/:id(*)', function (req, res, next) {
       + '/' + req.params.db
       + '/' + req.body._id;
     res.location(loc);
+    res.send(201, response);
+  });
+});
+
+// Create a document
+app.post('/:db(*)', function (req, res, next) {
+  req.db.post(req.body, req.query, function (err, response) {
+    if (err) return res.send(409, err);
     res.send(201, response);
   });
 });


### PR DESCRIPTION
Hi, 

Thanks for pouchdb-server, it is very cool and very useful. Here is a patch to support creating documents via `POST`. Currently pouchdb-server only supports creation via a `PUT`. Couchdb has the `POST` to (create documents)[https://couchdb.readthedocs.org/en/latest/api/documents.html] that don't have an Id.
