### PR TITLE
exit gracefully on SIGINT

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -67,3 +67,6 @@ app.use(require('express-pouchdb'));
 app.listen(port);
 console.log('pouchdb-server listening on port ' + port + '.\n');
 
+process.on('SIGINT', function () {
+  process.exit(0)
+})


### PR DESCRIPTION
This makes it easier to use `pouchdb-server` in a test runner
so that you can be sure it exited cleanly.

I noticed there is another issue about destroying data on exit, but it's not at all clear to me where pouchdb-express is storing it's data at all.
