### PR TITLE
(pouchdb/pouchdb#2573) - lock express to 4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "corser": "~1.2.0",
     "couchdb-harness": "*",
-    "express": "4.x",
+    "express": "4.6.1",
     "express-pouchdb": "*",
     "memdown": "0.10.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
This solves the issue.
