### PR TITLE
Serve favicon from memory

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -2,6 +2,7 @@
 
 var express = require('express')
   , corser  = require('corser')
+  , favicon = require('serve-favicon')
   , path    = require('path')
   , mkdirp  = require('mkdirp')
   , argv    = require('optimist').argv
@@ -31,7 +32,7 @@ if (argv.h || argv.help) {
   process.exit(1);
 }
 
-app.use('/favicon.ico', express.static(__dirname + '/../favicon.ico'));
+app.use(favicon(__dirname + '/../favicon.ico'));
 app.use(require('morgan')(logger));
 app.use(function (req, res, next) {
   corserRequestListener(req, res, function () {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mkdirp": "^0.5.0",
     "morgan": "^1.1.1",
     "optimist": "~0.3.5",
-    "pouchdb": "pouchdb/pouchdb"
+    "pouchdb": "pouchdb/pouchdb",
+    "serve-favicon": "~2.0.1"
   }
 }


### PR DESCRIPTION
This changes the favicon serving to the `serve-favicon` module which will serve it up from memory instead of reading from the disk for every request.

This is not particularly necessary, just thought you may like it.
