### PR TITLE
Replace app.all("*", fn) with app.use(fn)

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -45,7 +45,7 @@ app.use(function (req, res, next) {
 });
 
 if (useAuth) {
-  app.all('*', function (req, res, next) {
+  app.use(function (req, res, next) {
     var auth = req.headers.authorization;
     // Default read-only
     if (req.user || req.method === 'GET') return next();


### PR DESCRIPTION
This replaces a use of `app.all('*', fn)` with `app.use(fn)`, because there are some differences between them:
1. The `.all` use will match against a regular expression with a capture group for every request
2. The `.all` will break `OPTIONS` request coming in, since it'll capture them and response with "yes, for every since method at every single URL"

This change it's technically necessary, but it's the better way to do what you want in express and you won't be impacted by the path changes in express 5.0 (the path `'*'` won't be valid any more).
