### PR TITLE
Update corser to 2.0.0

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -14,11 +14,7 @@ var express = require('express')
   , levelBackend = argv['level-backend']
   , levelPrefix  = argv['level-prefix']
   , useAuth = user && pass
-  , app     = express()
-  , corserRequestListener = corser.create({
-      methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'],
-      supportsCredentials: true
-  });
+  , app     = express();
 
 // Help, display usage information
 if (argv.h || argv.help) {
@@ -33,16 +29,10 @@ if (argv.h || argv.help) {
 
 app.use('/favicon.ico', express.static(__dirname + '/../favicon.ico'));
 app.use(require('morgan')(logger));
-app.use(function (req, res, next) {
-  corserRequestListener(req, res, function () {
-    if (req.method == 'OPTIONS') {
-      // End CORS preflight request.
-      res.writeHead(204);
-      return res.end();
-    }
-    next();
-  });
-});
+app.use(corser.create({
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'],
+  supportsCredentials: true
+}));
 
 if (useAuth) {
   app.all('*', function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "corser": "~1.2.0",
+    "corser": "~2.0.0",
     "couchdb-harness": "*",
     "express": "4.6.1",
     "express-pouchdb": "*",


### PR DESCRIPTION
This will update the `corser` module to 2.0.0. The main effect is you don't need to end the preflight requests yourself with a 204--`corser` now does that for you by default: https://github.com/agrueneberg/Corser#20-march-22-2014
