### PR TITLE
(#65) - add all_dbs db to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ testdb_*
 test_*
 _pouch_*
 _allDbs
+pouch__all_dbs__
 npm-debug.log


### PR DESCRIPTION
This has been annoying me for awhile; it shows up when we run our tests.
