### PR TITLE
(#78) - remove phantom/firefox from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ env:
 matrix:
   allow_failures:
   - env: COMMAND=test-couchdb
-  - env: CLIENT=selenium:firefox COMMAND=test-pouchdb
-  - env: CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test-pouchdb
 
 branches:
   only:


### PR DESCRIPTION
Before merging, let's make sure the tests are actually being run. (My trick is to grep the log for `lastPassed` and then make sure that the last one has ~1000 tests run.)

It looks like the old instability issues have been fixed, but it's good to be sure. :)
