### PR TITLE
(#67) - Add proxy to a remote db support

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -52,6 +52,10 @@ function parseArgs() {
       flag: 'true',
       help: terminalWrap("Use a pure in-memory database (will be deleted upon restart!)")
     },
+    proxy: {
+      abbr: 'r',
+      help: terminalWrap("Proxy requests to the specified host. Include a trailing '/'. Defaults to not active ('null')."),
+    },
     logMode: {
       abbr: 'l',
       full: 'log',
@@ -187,7 +191,12 @@ function updatePouchDB() {
     opts.db = require(args.levelBackend);
   }
 
-  var PouchDB = require('pouchdb').defaults(opts);
+  var PouchDB;
+  if (args.proxy) {
+    PouchDB = require('http-pouchdb')(require('pouchdb'), args.proxy);
+  } else {
+    PouchDB = require('pouchdb').defaults(opts);
+  }
   pouchDBApp.setPouchDB(PouchDB);
 }
 config.registerDefault('couchdb', 'database_dir', './');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "couchdb-harness": "*",
     "express": "4.10.4",
     "express-pouchdb": "*",
+    "http-pouchdb": "^1.1.0",
     "killable": "^1.0.0",
     "memdown": "0.10.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Requires pouchdb/express-pouchdb#156 to be merged first.

The proxy feature is still new: the core db stuff + fauxton (probably the most important use case) works. /_config still shows the local configuration data though (and I'm not sure if that should actually change).

Also the plug-ins behind _users, _replicator and show/list/update currently mostly assume that an http database means couchdb; they might not work correctly when the backend is something else like, say, pouchdb-express-router, or one of the couchbase things. That's something that can be improved on mostly in the plug-ins themselves, though.