### PR TITLE
(#84) - Remove duplicate functionality

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,7 @@
     "afterEach",
     "testUtils",
     "emit",
-    "EventSource"
+    "EventSource",
+    "-Promise"
   ]
 }

--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -52,6 +52,10 @@ function parseArgs() {
       flag: 'true',
       help: terminalWrap("Use a pure in-memory database (will be deleted upon restart!)")
     },
+    proxy: {
+      abbr: 'r',
+      help: terminalWrap("Proxy requests to the specified host. Include a trailing '/'. Defaults to not active ('null')."),
+    },
     logMode: {
       abbr: 'l',
       full: 'log',
@@ -187,7 +191,12 @@ function updatePouchDB() {
     opts.db = require(args.levelBackend);
   }
 
-  var PouchDB = require('pouchdb').defaults(opts);
+  var PouchDB;
+  if (args.proxy) {
+    PouchDB = require('http-pouchdb')(require('pouchdb'), args.proxy);
+  } else {
+    PouchDB = require('pouchdb').defaults(opts);
+  }
   pouchDBApp.setPouchDB(PouchDB);
 }
 config.registerDefault('couchdb', 'database_dir', './');

--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -3,14 +3,16 @@
 "use strict";
 
 var express  = require('express'),
-    auth     = require('basic-auth'),
     corser   = require('corser'),
     favicon  = require('serve-favicon'),
     path     = require('path'),
     mkdirp   = require('mkdirp'),
     nomnom   = require('nomnom'),
     wordwrap = require('wordwrap'),
-    killable = require('killable');
+    killable = require('killable'),
+    tailLog  = require('../lib/logging');
+
+// parse command line arguments
 
 function terminalWrap(text) {
   // 21 chars from the left of the terminal might change when new
@@ -20,8 +22,6 @@ function terminalWrap(text) {
 
 function parseArgs() {
   /* jshint maxlen:false */
-
-  var loggerModes = ['dev', 'short', 'tiny', 'combined', 'off'];
 
   var options = {
     port: {
@@ -54,22 +54,13 @@ function parseArgs() {
     },
     proxy: {
       abbr: 'r',
-      help: terminalWrap("Proxy requests to the specified host. Include a trailing '/'. Defaults to not active ('null')."),
+      help: terminalWrap("Proxy requests to the specified host. Include a trailing '/'. Defaults to not active ('null').")
     },
-    logMode: {
-      abbr: 'l',
-      full: 'log',
-      default: 'dev',
-      choices: loggerModes,
-      help: terminalWrap("Output log format (" + loggerModes.join('|') + ")")
-    },
-    user: {
-      abbr: 'u',
-      help: terminalWrap("Set Basic Auth username. (Both user and pass required for Basic Auth).")
-    },
-    pass: {
-      abbr: 's',
-      help: terminalWrap("Set Basic Auth password. (Both user and pass required for Basic Auth).")
+    noColor: {
+      // this option is handled by the 'colors' node module. It's just
+      // here so it shows up in --help
+      full: 'no-color',
+      help: terminalWrap("Disable coloring of logging output.")
     },
     levelBackend: {
       full: 'level-backend',
@@ -99,39 +90,45 @@ function parseArgs() {
     .nocolors()
     .parse();
 
-  result.useAuth = result.user && result.pass;
   return result;
 }
 
 var args = parseArgs();
 
+// build app
+
 var app = express();
-app.use(favicon(__dirname + '/../favicon.ico'));
-
-if (args.logMode !== 'off') {
-  app.use(require('morgan')(args.logMode));
-}
-
-if (args.useAuth) {
-  app.use(function (req, res, next) {
-    // Default read-only
-    if (req.user || req.method === 'GET') {
-      return next();
-    }
-    // Otherwise authenticate
-    var creds = auth(req);
-    if (creds && creds.name === args.user && creds.pass === args.pass) {
-      return next();
-    }
-    res.send(401);
-  });
-}
 
 var pouchDBApp = require('express-pouchdb')({
   configPath: args.config
 });
 var config = pouchDBApp.couchConfig;
+var logger = pouchDBApp.couchLogger;
 
+// favicon
+app.use(favicon(__dirname + '/../favicon.ico'));
+
+// logging
+var stopTailingLogImpl, loggingReady;
+
+function restartTailingLog() {
+  stopTailingLog();
+  loggingReady = tailLog(config.get('log', 'file')).then(function (stop) {
+    stopTailingLogImpl = stop;
+  });
+}
+
+function stopTailingLog() {
+  if (stopTailingLogImpl) {
+    stopTailingLogImpl();
+    stopTailingLogImpl = undefined;
+  }
+}
+
+config.on('log.file', restartTailingLog);
+restartTailingLog();
+
+// cors
 var corsMiddleware;
 function corsChanged() {
   if (config.get('httpd', 'enable_cors')) {
@@ -175,6 +172,8 @@ app.use(function (req, res, next) {
   return corsMiddleware(req, res, next);
 });
 
+// determine PouchDB instance
+
 function updatePouchDB() {
   var opts = {};
 
@@ -205,35 +204,44 @@ updatePouchDB();
 
 app.use(pouchDBApp);
 
+// handle listening
+
 var server;
+
 function listen() {
+  loggingReady.then(listenImpl);
+}
+
+function listenImpl() {
   var host = args.host || config.get('httpd', 'bind_address');
   var port = args.port || config.get('httpd', 'port');
 
   server = app.listen(port, host, function () {
-    console.log('\npouchdb-server listening on port ' + port + '.');
+    var address = 'http://' + host + ':' + port + '/';
+    logger.info('pouchdb-server has started on ' + address);
     if (args.inMemory) {
-      console.log('database is in-memory; no changes will be saved.');
+      logger.info('database is in-memory; no changes will be saved.');
     } else if (args.dir) {
-      console.log('database files will be saved to ' + args.dir);
+      logger.info('database files will be saved to ' + args.dir);
     }
     if (args.levelBackend) {
-      console.log('using alternative backend: ' + args.levelBackend);
+      logger.info('using alternative backend: ' + args.levelBackend);
     }
     if (args.levelPrefix) {
       var prefix = args.levelPrefix;
-      console.log('all databases will be created with prefix: ' + prefix);
+      logger.info('all databases will be created with prefix: ' + prefix);
     }
-    var fauxtonUrl = 'http://' + host + ':' + port + '/_utils';
-    console.log('\nnavigate to ' + fauxtonUrl + ' for the Fauxton UI.\n');
+    var fauxtonUrl = address + '_utils';
+    logger.info('navigate to ' + fauxtonUrl + ' for the Fauxton UI.');
   });
   killable(server);
 
   server.on('error', function (e) {
+    stopTailingLog();
     if (e.code === 'EADDRINUSE') {
-      console.error('\nError: Port ' + port + ' is already in use.');
+      console.error('Error: Port ' + port + ' is already in use.');
       console.error('Try another one, e.g. pouchdb-server -p ' +
-        (parseInt(port) + 1) + '\n');
+        (parseInt(port) + 1));
     } else {
       console.error('Uncaught error: ' + e);
       console.error(e.stack);
@@ -250,6 +258,8 @@ config.registerDefault('httpd', 'bind_address', '127.0.0.1');
 config.on('httpd.port', rebind);
 config.on('httpd.bind_address', rebind);
 listen();
+
+// handle exit
 
 process.on('SIGINT', function () {
   process.exit(0);

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,80 @@
+"use strict";
+
+var Tail = require('tail').Tail;
+var LogParser = require('couchdb-log-parse');
+var colors = require('colors/safe');
+var fs = require('fs');
+var Promise = require('bluebird');
+
+var parser = new LogParser();
+parser.on('message', function (msg) {
+  var args = [fmtLevel(msg.level)];
+  if (msg.type === "http") {
+    args.push(msg.method, msg.url, fmtStatusCode(msg.statusCode));
+    args.push('-', colors.white(msg.ip));
+  } else if (msg.type === "erl") {
+    args.push((msg.message || '').trim(), msg.dump);
+  } else {
+    args.push((msg.raw || '').trim());
+  }
+  console.log.apply(console, args);
+});
+
+function fmtLevel(level) {
+  var text = '[' + (level || 'other') + ']';
+  return levelColor(level)(text);
+}
+
+function levelColor(level) {
+  return {
+    info: colors.green,
+    debug: colors.cyan,
+    error: colors.red,
+    warning: colors.yellow
+  }[level] || function (text) {
+    // no color
+    return text;
+  };
+}
+
+function fmtStatusCode(statusCode) {
+  return statusCodeColor(statusCode)(statusCode);
+}
+
+function statusCodeColor(status) {
+  if (status >= 500) {
+    return colors.red;
+  }
+  if (status >= 400) {
+    return colors.yellow;
+  }
+  if (status >= 300) {
+    return colors.cyan;
+  }
+  return colors.green;
+}
+
+module.exports = function tailLog(path) {
+  // Watches a couchdb style log file, when a new line gets available it
+  // is parsed. The interesting info in it is then pretty printed to
+  // stdout as parser output.
+
+  function startTailing() {
+    return new Promise(function (resolve, reject) {
+      fs.exists(path, function (exists) {
+        if (!exists) {
+          // try again in a bit
+          return resolve(startTailing());
+        }
+        var tail = new Tail(path);
+        tail.on('line', function (line) {
+          // double \n is necessary for the line to be processed.
+          parser.write(new Buffer(line + '\n\n', 'UTF-8'));
+        });
+        resolve(tail.unwatch.bind(tail));
+      });
+    });
+  }
+
+  return startTailing();
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "couchdb-harness": "*",
     "express": "4.10.4",
     "express-pouchdb": "*",
+    "http-pouchdb": "^1.1.0",
     "killable": "^1.0.0",
     "memdown": "0.10.1",
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -18,25 +18,27 @@
     "start": "node ./bin/pouchdb-server",
     "test-pouchdb": "./bin/test-pouchdb.sh",
     "test-couchdb": "./bin/test-couchdb.sh",
-    "jshint": "./node_modules/.bin/jshint bin/pouchdb-server"
+    "jshint": "./node_modules/.bin/jshint bin/pouchdb-server lib"
   },
   "engines": {
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "basic-auth": "~1.0.0",
+    "bluebird": "^2.4.2",
+    "colors": "^1.0.3",
     "corser": "~2.0.0",
     "couchdb-harness": "*",
+    "couchdb-log-parse": "0.0.3",
     "express": "4.10.4",
     "express-pouchdb": "*",
     "http-pouchdb": "^1.1.0",
     "killable": "^1.0.0",
     "memdown": "0.10.1",
     "mkdirp": "^0.5.0",
-    "morgan": "^1.1.1",
     "nomnom": "^1.8.1",
     "pouchdb": "pouchdb/pouchdb",
     "serve-favicon": "~2.0.1",
+    "tail": "^0.4.0",
     "wordwrap": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Based on  #83 to hopefully prevent conflicts.

Removes functionality that is implemented in express-pouchdb; often in a more sophisticated way. i.e.:
- http basic authentication
- logging

The technical implementation of the last in express-pouchdb is more versatile than pouchdb-server's, but it didn't look as well. This PR aims to solve that by parsing the log file while it is being written and by outputting the equivalent in a nicer way to stdout.