### PR TITLE
(#91) - fix test-couchdb

### DIFF
--- a/bin/test-couchdb.sh
+++ b/bin/test-couchdb.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-node bin/pouchdb-server -p 6984 &
+# use config file instead of command line option because
+# couchdb-harness depends on the fact that /_config/httpd/port equals
+# the port on which pouchdb-server is running.
+echo '{"httpd": {"port": 6984}}' > config.json
+node bin/pouchdb-server
 export POUCHDB_SERVER_PID=$!
 ./node_modules/couchdb-harness/bin/couchdb-harness -p 6984
 


### PR DESCRIPTION
Use config file instead of cli option for compatiblity with couchdb-harness's rewrite.js.