### PR TITLE
(pouchdb/pouchdb#4798) - use git master for tests

### DIFF
--- a/bin/test-pouchdb.sh
+++ b/bin/test-pouchdb.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+# install pouchdb from git master rather than npm,
+# so we can run its own tests
+rm -fr node_modules/pouchdb
+git clone --depth 1 --single-branch --branch master \
+  https://github.com/pouchdb/pouchdb.git node_modules/pouchdb
+
+cd node_modules/pouchdb/
+npm install
+
+cd ../..
+
 ./bin/pouchdb-server -p 6984 $SERVER_ARGS &
 POUCHDB_SERVER_PID=$!
 
 cd node_modules/pouchdb/
-npm install
 
 COUCH_HOST=http://localhost:6984 npm test
 


### PR DESCRIPTION
After pouchdb/pouchdb#4798, it's no longer safe to
use the npm version of pouchdb to test itself, because
the test files won't be in there.