### PR TITLE
Use process.env.port or 5984 as default port

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -20,7 +20,7 @@ var options = {
     abbr: 'p',
     info: "Port on which to run the server.",
     couchName: ['httpd', 'port'],
-    couchDefault: 5984,
+    couchDefault: process.env.port || 5984,
     onChange: rebind
   },
   dir: {


### PR DESCRIPTION
Makes it compatible to most hosting like heroku, dokku, etc