### PR TITLE
Use PORT env variable, not port

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ By default, logs are written to `./log.txt`.
 
 ## Automatic port configuration
 
-Due to conventions set by Heroku and others, if you have a `port` environment variable,
+Due to conventions set by Heroku and others, if you have a `PORT` environment variable,
 `pouchdb-server` will pick up on that and use it instead of `5984` as the default.
 
 ```bash
-export port=3000
+export PORT=3000
 pouchdb-server # will run on port 3000
 ```
 

--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -23,7 +23,7 @@ var options = {
     abbr: 'p',
     info: "Port on which to run the server.",
     couchName: ['httpd', 'port'],
-    couchDefault: process.env.port || 5984,
+    couchDefault: process.env.PORT || 5984,
     onChange: rebind
   },
   dir: {


### PR DESCRIPTION
On windows, env variables are not case sensitive, so port and PORT will work the same (Azure).

On UNIX, env variables are case sensitive and the convention is uppercase for them. Heroku and Dokku are using PORT and `process.env.port` won't work for them.

[skip ci]