### PR TITLE
(#138) - Fix tests & publish bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ _users
 _replicator
 config.json
 log.txt
+.idea
+*.log
+MANIFEST*
+CURRENT
+LOCK
+LOG
+.DS_Store

--- a/bin/test-pouchdb.sh
+++ b/bin/test-pouchdb.sh
@@ -2,11 +2,17 @@
 
 # install pouchdb from git master rather than npm,
 # so we can run its own tests
-rm -fr node_modules/pouchdb
+rm -fr node_modules/pouchdbclone
 git clone --depth 1 --single-branch --branch master \
-  https://github.com/pouchdb/pouchdb.git node_modules/pouchdb
+  https://github.com/pouchdb/pouchdb.git node_modules/pouchdbclone
 
-cd node_modules/pouchdb/
+cd node_modules/pouchdbclone/
+npm install
+npm build
+cd ../..
+rm -fr node_modules/pouchdb
+ln -s ./pouchdbclone/packages/pouchdb ./node_modules/pouchdb
+cd node_modules/pouchdb
 npm install
 
 cd ../..
@@ -14,7 +20,7 @@ cd ../..
 ./bin/pouchdb-server -n -p 6984 $SERVER_ARGS &
 POUCHDB_SERVER_PID=$!
 
-cd node_modules/pouchdb/
+cd node_modules/pouchdbclone/
 
 COUCH_HOST=http://localhost:6984 npm test
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "files": [
     "lib",
-    "bin/pouchdb-server",
+    "bin",
     "favicon.ico"
   ]
 }


### PR DESCRIPTION
#138 

.gitignore - Ignore files from running tests, Intellij and Mac stuff

test-pouchdb.sh - Set up PouchDB properly given new build behavior

package.json - Publish all the files in bin so that express-pouchdb tests
can run. I tested this with npm pack and it appears to work just fine.