### PR TITLE
Add license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A standalone REST interface server for PouchDB.",
   "version": "2.0.0",
   "homepage": "https://github.com/pouchdb/pouchdb-server",
+  "license": "Apache-2.0",
   "author": {
     "name": "Nick Thompson",
     "email": "ncthom91@gmail.com"


### PR DESCRIPTION
Makes both npm and license checking tools happy.
See: https://github.com/npm/npm/releases/tag/v2.10.0