### PR TITLE
(pouchdb/express-pouchdb#430) - add pouchdb-adapter-http to adapters list

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nomnom": "^1.8.1",
     "object-assign": "^4.1.0",
     "on-finished": "^2.3.0",
+    "pouchdb-adapter-http": "^6.1.0",
     "pouchdb-adapter-leveldb-core": "^6.1.0",
     "pouchdb-adapter-memory": "^6.1.0",
     "pouchdb-all-dbs": "^1.0.2",

--- a/packages/node_modules/pouchdb-server/lib/index.js
+++ b/packages/node_modules/pouchdb-server/lib/index.js
@@ -13,6 +13,7 @@ var Promise  = require('pouchdb-promise');
 var customLevelAdapter = require('./customLevelAdapter');
 
 var PouchDB  = require('pouchdb-core')
+  .plugin(require('pouchdb-adapter-http'))
   .plugin(require('pouchdb-replication'))
   .plugin(require('pouchdb-mapreduce'))
   .plugin(require('pouchdb-find'));


### PR DESCRIPTION
This is a partial fix for https://github.com/pouchdb/express-pouchdb/issues/430 . We can't replicate to/from http databases if we don't have the http adapter installed.