### PR TITLE
(#194) - remove phantom from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ env:
 matrix:
   allow_failures:
   - env: COMMAND=test-couchdb
-  - env: CLIENT=selenium:phantomjs COMMAND=test-pouchdb
 
 branches:
   only:


### PR DESCRIPTION
Looking at the past few builds, this has been passing. I see no reason to keep it as an allowed failure. `travis_retry` helps here as well.