### PR TITLE
improvements to test scripts

### DIFF
--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
+# Check out PouchDB itself from master and build it, so that we can
+# run its test suite.
+# Note: this will start to fail randomly if something changes in
+# PouchDB master. In those cases, just pin it to a specific Git commit.
+
 DIRECTORY='pouchdb-tests'
 
 if [ ! -d "$DIRECTORY" ]; then
   # Control will enter here if $DIRECTORY exists.
   git clone --single-branch --branch master \
+    --depth 1 \
     https://github.com/pouchdb/pouchdb.git ${DIRECTORY}
 fi
 
 cd pouchdb-tests
 npm install
-
 cd ..

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "unit-tests": "mocha tests/**/*",
     "test-pouchdb": "./bin/test-setup.sh && ./bin/test-pouchdb.sh",
-    "test-couchdb": "./bin/test-setup.sh && ./bin/test-couchdb.sh",
+    "test-couchdb": "./bin/test-couchdb.sh",
     "eslint": "eslint bin/ packages/node_modules/**/src tests/",
     "test-express-minimum": "./bin/test-setup.sh && ./bin/test-express-minimum.sh",
     "release": "node ./bin/prerelease.js && ./bin/release.sh"


### PR DESCRIPTION
1. There is no need to run `test-setup.sh` for `test-couchdb`
2. When we check out the pouchdb git repo, we can use `--depth 1` to make it faster