### PR TITLE
update sub-package readmes

### DIFF
--- a/packages/node_modules/express-pouchdb/README.md
+++ b/packages/node_modules/express-pouchdb/README.md
@@ -1,8 +1,9 @@
-# express-pouchdb
-
-[![Build Status](https://travis-ci.org/pouchdb/pouchdb-server.svg)](https://travis-ci.org/pouchdb/pouchdb-server)
+express-pouchdb [![Build Status](https://travis-ci.org/pouchdb/pouchdb-server.svg)](https://travis-ci.org/pouchdb/pouchdb-server)
+======
 
 An Express submodule with a CouchDB-style REST interface to PouchDB.
+
+For full documentation, see [the PouchDB Server readme](https://github.com/pouchdb/pouchdb-server#readme).
 
 ### Source
 

--- a/packages/node_modules/pouchdb-server/README.md
+++ b/packages/node_modules/pouchdb-server/README.md
@@ -1,8 +1,9 @@
-# express-pouchdb
-
-[![Build Status](https://travis-ci.org/pouchdb/pouchdb-server.svg)](https://travis-ci.org/pouchdb/pouchdb-server)
+pouchdb-server [![Build Status](https://travis-ci.org/pouchdb/pouchdb-server.svg)](https://travis-ci.org/pouchdb/pouchdb-server)
+======
 
 A drop-in replacement for CouchDB, built on Node.js and PouchDB.
+
+For full documentation, see [the PouchDB Server readme](https://github.com/pouchdb/pouchdb-server#readme).
 
 ### Source
 


### PR DESCRIPTION
These readmes are a little confusing if you land on them on the npmjs.com website. This tweaks them to add better links back to the main documentation.