### PR TITLE
Test in Node v4 and v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,13 @@ env:
   - COMMAND=test-couchdb
  
 matrix:
+  fast_finish: true
+  include:
+    - node_js: "4"
+      env: CLIENT=node COMMAND=test-pouchdb
+  include:
+    - node_js: "7"
+      env: CLIENT=node COMMAND=test-pouchdb
   allow_failures:
   - env: COMMAND=test-couchdb
 


### PR DESCRIPTION
We can't support Node <4 because eslint requires >=4, but we can at least verify that everything works in Node 4. We should also test Node v7 because it's the latest.