### PR TITLE
cache npm, selenium, and phantom in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,14 @@ before_script:
   # The next two lines are required for Firefox to run on Travis
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  # Install PhantomJS and cache it
+  # See https://github.com/Medium/phantomjs#continuous-integration
+  - "export PHANTOMJS_VERSION=2.1.1"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
   # Fail early if there's a eslint problem
   - npm run eslint
 
@@ -56,3 +64,11 @@ matrix:
 branches:
   only:
   - master
+
+cache:
+  directories:
+  - $HOME/.npm
+  # See https://github.com/gr2m/selsa
+  - node_modules/selenium-standalone/.selenium
+  # See https://github.com/Medium/phantomjs#continuous-integration
+  - travis_phantomjs


### PR DESCRIPTION
This copies over the same Travis caching we use in PouchDB, which has shown measurable improvements in our build times.