### PR TITLE
update readme about "production ready"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Node.js. It is modeled after the single-node design of CouchDB 1.x,
 although it contains some CouchDB 2.x features such as
 [Mango queries](http://github.com/nolanlawson/pouchdb-find).
 
-PouchDB Server is not designed for production environments, as it is much less
-battle-tested than CouchDB. However, it can be useful for development,
-testing, and prototypes. It passes the full [PouchDB test suite](https://github.com/pouchdb/pouchdb/tree/master/tests).
+PouchDB Server is much less battle-tested than CouchDB, but it does pass the full [PouchDB test suite](https://github.com/pouchdb/pouchdb/tree/master/tests).
 
 _For the `express-pouchdb` sub-package, skip to [express-pouchdb](#express-pouchdb)._
 


### PR DESCRIPTION
"Production ready" is a value judgment, and this sentence seems to be causing more confusion than it's worth. Maybe it's better just to be neutral and say what PouchDB Server can and cannot do.

Especially in an age where weekend hack projects end up on Hacker News with 1000s of GitHub stars, maybe I shouldn't sell this project short. We worked damn hard to have a reliable test suite and to get it to support a dizzying array of CouchDB features, so labeling it "not ready for production" is maybe over-humble.