### PR TITLE
Parse different replication objects

### DIFF
--- a/packages/node_modules/pouchdb-replicator/lib/index.js
+++ b/packages/node_modules/pouchdb-replicator/lib/index.js
@@ -24,6 +24,7 @@ var equals = require('equals');
 var extend = require('extend');
 var PouchPluginError = require('pouchdb-plugin-error');
 var systemDB = require('pouchdb-system-db');
+const url = require('url');
 
 //to update: http://localhost:5984/_replicator/_design/_replicator & remove _rev.
 var DESIGN_DOC = require('./designdoc.js');
@@ -99,6 +100,26 @@ exports.startReplicatorDaemon = function (callback) {
   return promise;
 };
 
+const createSafeUrl = (source) => {
+  if (typeof source === 'string') {
+    return source;
+  }
+
+  if (source.name) {
+    return source;
+  }
+
+  const formattedUrl = url.parse(source.url);
+  if (source.headers.Authorization) {
+    const base64Auth = Buffer.from(source.headers.Authorization.replace("Basic ",""), 'base64');
+    formattedUrl.auth = base64Auth.toString('utf-8');
+  }
+
+  return url.format(formattedUrl);
+};
+
+exports.createSafeUrl = createSafeUrl;
+
 function onChanged(db, doc) {
   //Stops/starts replication as required by the description in ``doc``.
 
@@ -150,7 +171,7 @@ function onChanged(db, doc) {
     var PouchDB = db.constructor;
     doc.userCtx = doc.user_ctx;
     var opts = extend({retry: true}, doc);
-    var replication = PouchDB.replicate(doc.source, doc.target, opts);
+    var replication = PouchDB.replicate(createSafeUrl(doc.source), createSafeUrl(doc.target), opts);
     data.activeReplicationsById[doc._id] = replication;
     data.activeReplicationSignaturesByRepId[doc._replication_id] = currentSignature;
 

--- a/tests/pouchdb-replicator/test.js
+++ b/tests/pouchdb-replicator/test.js
@@ -15,6 +15,48 @@ const replicationDocument = {
 
 let db;
 
+describe('replicator url helper', () => {
+	const createSafeUrl = Replicator.createSafeUrl;
+
+	it("handles string", () => {
+		const db = "db-name";
+		const out = createSafeUrl(db);
+		out.should.equal(db);
+	});
+
+	it("handles name object", () => {
+		const db = {
+			name: "db-name"
+		};
+
+		const out = createSafeUrl(db);
+		out.should.equal(db);
+	});
+
+	it("returns url without auth", () => {
+		const source = {
+			headers: {},
+			url: 'http://dev:5984/animaldb-clone'
+		};
+
+		const out = createSafeUrl(source);
+		out.should.equal(source.url);
+	});
+
+	it("returns url with auth", () => {
+		const source = {
+			headers: {
+				Authorization: "Basic dGVzdGVyOnRlc3RlcnBhc3M="
+			},
+			url: 'http://dev:5984/animaldb-clone'
+		};
+
+		const out = createSafeUrl(source);
+		out.should.equal('http://tester:testerpass@dev:5984/animaldb-clone');
+	});
+
+});
+
 describe('async replicator tests', () => {
 	beforeEach(() => {
 		db = setup();


### PR DESCRIPTION
When replicating the source and target can be an object with an auth
header. This parses the source and target and creates an url that the
replicator can handle