### PR TITLE
Expose "pouchdb-adapters" list for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "wordwrap": "1.0.0"
   },
   "devDependencies": {
+    "assert": "^1.4.1",
     "bluebird": "^3.4.7",
     "builtin-modules": "^1.1.1",
     "eslint": "3.15.0",

--- a/packages/node_modules/express-pouchdb/lib/routes/root.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/root.js
@@ -13,7 +13,8 @@ module.exports = function (app) {
   app.get('/', function (req, res) {
     var json = {
       'express-pouchdb': 'Welcome!',
-      'version': pkg.version
+      'version': pkg.version,
+      'pouchdb-adapters': req.PouchDB.preferredAdapters
     };
     function sendResp() {
       utils.sendJSON(res, 200, json);

--- a/tests/express-pouchdb/test.js
+++ b/tests/express-pouchdb/test.js
@@ -8,7 +8,8 @@ var buildApp = require('../../packages/node_modules/express-pouchdb'),
     request  = require('supertest'),
     Promise  = require('bluebird'),
     fse      = Promise.promisifyAll(require('fs-extra')),
-    memdown  = require('memdown');
+    memdown  = require('memdown'),
+    assert   = require('assert');
 
 var TEST_DATA = __dirname + '/testdata/';
 var LARGE_TIMEOUT = 5000;
@@ -180,6 +181,17 @@ prefixes.forEach(function (prefix) {
       app.use(prefix, expressApp);
 
       testWelcome(app, done, prefix);
+    });
+    it('GET / should respond with adapters', function () {
+      var app = express();
+      app.use(prefix, expressApp);
+      return request(app)
+        .get(prefix)
+        .expect(200)
+        .then(function (res) {
+          var json = JSON.parse(res.text);
+          assert.deepEqual(json['pouchdb-adapters'], ['leveldb']);
+        });
     });
   });
 });


### PR DESCRIPTION
With this change, the JSON returned for `GET /` returns e.g.:

```js
{
  /* ... */
  "pouchdb-adapters": ["leveldb"]
}
```

or:

```js
{
  /* ... */
  "pouchdb-adapters": ["node-websql"]
}
```

or:

```js
{
  /* ... */
  "pouchdb-adapters": ["memory"]
}
```

I believe this aids in debuggability, e.g. when you do `pouchdb-server --in-memory` and want to remember that it's in-memory.

The test fails before the fix but succeeds after.