### PR TITLE
Allow passing options to mocha

### DIFF
--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -3,7 +3,7 @@
 ./packages/node_modules/pouchdb-server/bin/pouchdb-server -m -n -p 5984 $SERVER_ARGS &
 POUCHDB_SERVER_PID=$!
 
-COUCH_HOST=http://localhost:5984 TIMEOUT=120000 mocha ./tests/**/*
+COUCH_HOST=http://localhost:5984 TIMEOUT=120000 mocha ./tests/**/* $1
 
 EXIT_STATUS=$?
 if [[ ! -z $POUCHDB_SERVER_PID ]]; then


### PR DESCRIPTION
This lets you pass `debug` or mocha flags when running unit tests.