### PR TITLE
(#264) Add Blob support when reading attachments

### DIFF
--- a/packages/node_modules/express-pouchdb/lib/routes/attachments.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/attachments.js
@@ -70,7 +70,7 @@ module.exports = function (app) {
       if (att instanceof Blob) {
         var reader = new FileReader();
         reader.onload = function() {
-          res.status(200).send(reader.result);
+          res.status(200).send(new Buffer(reader.result));
         };
         reader.onerror = function () {
           utils.sendError(res, reader.error);

--- a/packages/node_modules/express-pouchdb/lib/routes/attachments.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/attachments.js
@@ -67,7 +67,7 @@ module.exports = function (app) {
       res.set('ETag', JSON.stringify(md5));
       res.setHeader('Content-Type', type);
       // attachments can be Blobs
-      if (att instanceof Blob) {
+      if (typeof Blob !== 'undefined' && att instanceof Blob) {
         var reader = new FileReader();
         reader.onload = function() {
           res.status(200).send(new Buffer(reader.result));

--- a/packages/node_modules/express-pouchdb/lib/routes/attachments.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/attachments.js
@@ -66,7 +66,20 @@ module.exports = function (app) {
 
       res.set('ETag', JSON.stringify(md5));
       res.setHeader('Content-Type', type);
-      res.status(200).send(att);
+      // attachments can be Blobs
+      if (att instanceof Blob) {
+        var reader = new FileReader();
+        reader.onload = function() {
+          res.status(200).send(reader.result);
+        };
+        reader.onerror = function () {
+          utils.sendError(res, reader.error);
+        };
+        reader.readAsArrayBuffer(blob);
+      // or Buffers
+      } else {
+        res.status(200).send(att);
+      }
     }).catch(function (err) {
       utils.sendError(res, err);
     });

--- a/packages/node_modules/express-pouchdb/lib/routes/attachments.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/attachments.js
@@ -75,7 +75,7 @@ module.exports = function (app) {
         reader.onerror = function () {
           utils.sendError(res, reader.error);
         };
-        reader.readAsArrayBuffer(blob);
+        reader.readAsArrayBuffer(att);
       // or Buffers
       } else {
         res.status(200).send(att);


### PR DESCRIPTION
In some configuations (e.g. when used with pouchdb-adapter-idb inside Electron)
attachments might be stored as Blobs instead of Buffers.