### PR TITLE
pouchdb-find dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pouchdb-collections": "^6.1.2",
     "pouchdb-core": "^6.1.0",
     "pouchdb-fauxton": "^0.0.6",
-    "pouchdb-find": "^0.10.4",
+    "pouchdb-find": "^6.1.0",
     "pouchdb-list": "^1.1.0",
     "pouchdb-mapreduce": "^6.1.0",
     "pouchdb-plugin-error": "^1.0.1",


### PR DESCRIPTION
Small update to pouchdb-find dependency to match the other main PouchDB
deps.  The pouchdb-find plugin was pulled into the main pouchdb repo.