### PR TITLE
Example for the REDIS_URL for the redisdown

### DIFF
--- a/packages/node_modules/pouchdb-server/lib/index.js
+++ b/packages/node_modules/pouchdb-server/lib/index.js
@@ -221,6 +221,7 @@ function updatePouchDB() {
     PouchDB.plugin(require('pouchdb-adapter-memory'));
   } else if (getArg('level-backend')) {
     PouchDB.plugin(customLevelAdapter(require(getArg('level-backend'))));
+    opts.url = process.env.LEVEL_DOWN_URL; // example could be the redis url
   } else if (getArg('sqlite')) {
     PouchDB.plugin(require('pouchdb-adapter-node-websql'));
   } else {


### PR DESCRIPTION
This is a quick and dirty example of where I put the redisdown REDIS_URL in so that one could use redis on 
heroku or if your redis server is not on localhost.  This example is based on a 2016 hack that I did, and I
haven't proved it out on the most recent plugin based code.