### PR TITLE
(#317) - Add allow_persistent_cookies config

### DIFF
--- a/packages/node_modules/express-pouchdb/lib/routes/authentication.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/authentication.js
@@ -18,6 +18,7 @@ module.exports = function (app) {
   app.couchConfig.registerDefault(SECTION, 'timeout', 600);
   app.couchConfig.registerDefault(SECTION, 'secret', Auth.generateSecret());
   app.couchConfig.registerDefault(SECTION, 'iterations', 10);
+  app.couchConfig.registerDefault(SECTION, 'allow_persistent_cookies', false);
 
   // explain how to activate the auth db logic.
   app.dbWrapper.registerWrapper(function (name, db, next) {
@@ -79,6 +80,7 @@ module.exports = function (app) {
   app.couchConfig.on(SECTION + '.timeout', refreshUsersDB);
   app.couchConfig.on(SECTION + '.secret', refreshUsersDB);
   app.couchConfig.on(SECTION + '.iterations', refreshUsersDB);
+  app.couchConfig.on(SECTION + '.allow_persistent_cookies', refreshUsersDB);
   app.couchConfig.on('admins', refreshUsersDB);
 
   // routing
@@ -108,7 +110,11 @@ module.exports = function (app) {
       return db.multiUserSession(sessionID);
     }).then(function (session) {
       if (session.info.authenticated) {
-        res.cookie('AuthSession', session.sessionID, {httpOnly: true});
+        var cookieOptions = {httpOnly: true};
+        if (app.couchConfig.get(SECTION, 'allow_persistent_cookies') === true) {
+          cookieOptions['maxAge'] = app.couchConfig.get(SECTION, 'timeout');
+        }
+        res.cookie('AuthSession', session.sessionID, cookieOptions);
         delete session.sessionID;
         session.info.authenticated = 'cookie';
         logSuccess('cookie', session);


### PR DESCRIPTION
Why:
To have an easy way of persisting user's session

What:
Implement `allow_persistent_cookies` setting from CouchDB (https://github.com/apache/couchdb/blob/817b2b6f5f0883092df60c1ec8ec7ec6d6094a23/src/couch/src/couch_httpd_auth.erl#L443)

I couldn't find any tests responsible for the actual cookies. Maybe you can point me into the right direction?