### PR TITLE
Fixes the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: node_js
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,6 @@ matrix:
   include:
     - node_js: "4"
       env: CLIENT=node COMMAND=test-pouchdb
-  include:
-    - node_js: "7"
-      env: CLIENT=node COMMAND=test-pouchdb
   allow_failures:
   - env: COMMAND=test-couchdb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - node_js: "4"
+    - node_js: "8"
       env: CLIENT=node COMMAND=test-pouchdb
   allow_failures:
   - env: COMMAND=test-couchdb


### PR DESCRIPTION
Drop testing on Node 4 and Node 7, replacing them with Node 8.
Use Ubuntu Trust to get Firefox testing to work.