### PR TITLE
fix(express-pouchdb): support _changes?filter=_selector

### DIFF
--- a/packages/node_modules/express-pouchdb/lib/routes/changes.js
+++ b/packages/node_modules/express-pouchdb/lib/routes/changes.js
@@ -24,6 +24,10 @@ module.exports = function (app) {
       req.query.doc_ids = req.body.doc_ids;
     }
 
+    if (req.query.filter === '_selector' && req.body && req.body.selector) {
+      req.query.selector = req.body.selector
+    }
+
     if (req.query.feed === 'continuous' || req.query.feed === 'longpoll') {
       var heartbeatInterval;
       // 60000 is the CouchDB default


### PR DESCRIPTION
This will allow the combination of `changes` and `selector`. It seems to be the default request when using `db.sync(..., { selector: { type: 'book' } })` for example.