### PR TITLE
Allowing daemons to stop

### DIFF
--- a/packages/node_modules/express-pouchdb/lib/replicator.js
+++ b/packages/node_modules/express-pouchdb/lib/replicator.js
@@ -56,8 +56,9 @@ module.exports = function enableReplicator(app) {
 
       return serialExecution(function () {
         var name = getReplicatorDBName();
-        return getOrCreateDB(PouchDB, name).then(function (db) {
+        return getOrCreateDB(PouchDB, name).then(function (theDb) {
           PouchDB.on('destroyed', onDestroy);
+          db = theDb;
           return db.startReplicatorDaemon();
         });
       });

--- a/packages/node_modules/express-pouchdb/lib/utils.js
+++ b/packages/node_modules/express-pouchdb/lib/utils.js
@@ -297,12 +297,16 @@ exports.requires = function (app, part) {
 exports.callAsyncRecursive = function (funcs, handleCall) {
   var i = 0;
   function next() {
-    var func = funcs[i];
-    if (typeof func === 'undefined') {
+    if (i === funcs.length) {
       return Promise.resolve();
     }
+    var func = funcs[i];
     i++;
-    return handleCall(func, next);
+    if (typeof func === 'undefined') {
+      return next();
+    } else {
+      return handleCall(func, next);
+    }
   }
   return next();
 };

--- a/packages/node_modules/pouchdb-replicator/lib/index.js
+++ b/packages/node_modules/pouchdb-replicator/lib/index.js
@@ -194,10 +194,14 @@ function dataFor(db) {
 
 function cleanupReplicationData(db, doc) {
   //cleanup replication data which is now no longer necessary
-  var data = dataFor(db);
-
-  delete data.activeReplicationsById[doc._id];
-  delete data.activeReplicationSignaturesByRepId[doc._replication_id];
+  var data
+  try {
+    data = dataFor(db);
+    delete data.activeReplicationsById[doc._id];
+    delete data.activeReplicationSignaturesByRepId[doc._replication_id];
+  } catch (err) {
+    // Already cleaned up
+  }
 }
 
 function getMatchingSignatureId(db, searchedSignature) {
@@ -248,7 +252,12 @@ function putAsReplicatorChange(db, doc) {
     doc._replication_state_time = new Date().toISOString();
   }
 
-  var data = dataFor(db);
+  var data;
+  try {
+    data = dataFor(db);
+  } catch (err) {  // Inactive
+    return Promise.resolve();
+  }
   data.changedByReplicator.push(doc._id);
 
   return db.put(doc, {


### PR DESCRIPTION
Couple of issues which made it very hard to stop and start an `express-pouchdb` server with active replications in defined in a `_replicator` document.
- in `replicator.js`, the db variable was never set, so `undefined` for `db.stopReplicatorDaemon`
- `callAsyncRecursive` typically stops on the first daemon, since it doesn't have a `stop` method, and thus `func[0] === undefined`
- The promises set up after replication completion in `pouchch-replication` fire up right after the daemon gets shut down, and throw exceptions on missing db within `dbData.dbs` which is empty, when trying to clean up the replication (which already has been cleaned when shutting the daemon down).
Open to better ways to do this. Thank you!