### PR TITLE
fix validation+replication bug

### DIFF
--- a/packages/node_modules/pouchdb-validation/lib/index.js
+++ b/packages/node_modules/pouchdb-validation/lib/index.js
@@ -32,7 +32,9 @@ function oldDoc(db, id) {
 }
 
 function validate(validationFuncs, newDoc, oldDoc, options) {
-  newDoc._revisions = (oldDoc || {})._revisions;
+  if(!newDoc._revisions && oldDoc) {
+    newDoc = Object.assign({_revisions:oldDoc._revisions},newDoc);
+  }
 
   try {
     validationFuncs.forEach(function (validationFuncInfo) {


### PR DESCRIPTION
fix a bug where newDoc was mutated by validation functions resulting in replication failing.
newDoc must not be modified since it affects later calls to document updating.

issue #419 