### PR TITLE
Make pouchdb-wrappers private

### DIFF
--- a/packages/node_modules/pouchdb-wrappers/package.json
+++ b/packages/node_modules/pouchdb-wrappers/package.json
@@ -16,5 +16,6 @@
   ],
   "license": "Apache-2.0",
   "author": "Marten de Vries",
-  "main": "lib/index.js"
+  "main": "lib/index.js",
+  "private": true
 }


### PR DESCRIPTION
The `pouchdb-wrappers` npm module is now published from the canonical repository at https://github.com/pouchdb-community/pouchdb-wrappers. I don't know what other internal changes would be necessary in this repo to migrate to the published version instead of this internal one, but marking it as private will at least stop it being accidentally published from this repository.