### PR TITLE
Add note about node-sqlite3 & node.js v14 max

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Or it can run using SQLite rather than LevelDB:
 
     pouchdb-server --sqlite
 
+**NOTE:** The underlying [`node-sqlite3`](https://github.com/mapbox/node-sqlite3#supported-platforms)
+currently only supports up to Node.js v14.
+
 ### Full options
 
 Most PouchDB Server options are available via the command line:


### PR DESCRIPTION
Running pouchdb-server on v14 (or earlier) works great. Running it after v14 fails due to `node-sqlite3` only supporting up to Node.js v14: https://github.com/mapbox/node-sqlite3#supported-platforms

This is just a README "fix" to help folks figure it out sooner/faster.

Cheers!
🎩 